### PR TITLE
fix: change header to narayana DevOps Operations Dashboard

### DIFF
--- a/poc-streamlit-devops/app.py
+++ b/poc-streamlit-devops/app.py
@@ -68,7 +68,7 @@ if selected_service:
     incidents = incidents[incidents["service"].isin(selected_service)]
 
 # ── Page title ────────────────────────────────────────────────────────────────
-st.title("🚀 MCPDevOps Operations Dashboard")
+st.title("🚀 narayana DevOps Operations Dashboard")
 st.caption(f"Last {days} days · {datetime.now().strftime('%Y-%m-%d %H:%M')}")
 st.markdown("---")
 


### PR DESCRIPTION
Change the page header in app.py from "MCPDevOps Operations Dashboard" to "narayana DevOps Operations Dashboard" as requested in issue #6.

Generated with [Claude Code](https://claude.ai/code)